### PR TITLE
Compatibility additions

### DIFF
--- a/bnkextr.cpp
+++ b/bnkextr.cpp
@@ -47,6 +47,8 @@ ENVS
 #include <fstream>
 #include <iostream>
 #include <vector>
+#include <string>
+#include <stdint.h>
 
 struct Index;
 struct Section;
@@ -56,14 +58,14 @@ struct Index
 {
 	int unknown;
 	int offset;
-	unsigned int size;
+	uint32_t size;
 };
 
 #pragma pack(push, 1)
 struct Section
 {
 	char sign[4];
-	unsigned int size;
+	uint32_t size;
 };
 #pragma pack(pop)
 #pragma pack(pop)

--- a/bnkextr.cpp
+++ b/bnkextr.cpp
@@ -48,7 +48,7 @@ ENVS
 #include <iostream>
 #include <vector>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 struct Index;
 struct Section;
@@ -56,16 +56,16 @@ struct Section;
 #pragma pack(push, 1)
 struct Index
 {
-	int unknown;
-	int offset;
-	uint32_t size;
+	std::uint32_t unknown;
+	std::uint32_t offset;
+	std::uint32_t size;
 };
 
 #pragma pack(push, 1)
 struct Section
 {
 	char sign[4];
-	uint32_t size;
+	std::uint32_t size;
 };
 #pragma pack(pop)
 #pragma pack(pop)


### PR DESCRIPTION
Added #include <string> because the std's don't work without (no idea how it worked without the include on your end? But on my end it didn't work without it). And changed to uint32_t :)